### PR TITLE
Update Playlist to allow editing on many pages

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -535,6 +535,7 @@ def Playlist(oid, title, can_edit=False, offset=None):
                 Playlist,
                 title=oc.title2,
                 oid=oid,
+                can_edit=can_edit,
                 offset=res['nextPageToken'],
             ),
             title=u'%s' % L('Next page'),


### PR DESCRIPTION
In Playlist, when creating a NextPageObject, the can_edit option is lost; 
if we were able to edit on the first page, on all other pages we're not.
