### PR TITLE
update ytplayer regex

### DIFF
--- a/Contents/Services/Shared Code/video.pys
+++ b/Contents/Services/Shared Code/video.pys
@@ -61,7 +61,7 @@ USER_AGENT = (
     'Mobile/11B554a Safari/9537.54'
 )
 
-RE_DATA = Regex('ytplayer.config\s*=\s*({(?:.+)});\s*ytplayer.load\s*=')
+RE_DATA = Regex('ytplayer.config\s*=\s*({(?:.+)});\s*(?:ytplayer.web_player_context_config|ytplayer.load)\s*=')
 
 
 def GetServiceURL(vid, token='', hl=''):


### PR DESCRIPTION
There seems to be some changes to the ytplayer javascript which messes the regex. Adding an additional keyword `ytplayer.web_player_context_config` in the search to make the regex function properly while keeping `ytplayer.load` in there just to make sure it doesn't break anything.